### PR TITLE
Include stdlib.h in configure test

### DIFF
--- a/configure.ac.in
+++ b/configure.ac.in
@@ -31,6 +31,7 @@ AC_CACHE_CHECK([ _____ weak test for C void* <=> unsigned int conversion],
          [AC_LANG_SOURCE([[
 #include <limits.h>
 #include <stdio.h>
+#include <stdlib.h>
 
 unsigned test[] =
 {  0x00000000, 0x000000ff, 0x0000ff00, 0x00ff0000, 0xff000000


### PR DESCRIPTION
Fixes:

```
conftest.c:34:13: error: implicitly declaring library function 'exit' with type 'void (int) __attribute__((noreturn))' [-Werror,-Wimplicit-function-declaration]
```
