### PR TITLE
Update rcl.in

### DIFF
--- a/rcl/rcl.in
+++ b/rcl/rcl.in
@@ -211,6 +211,9 @@ elif [[ $themode == 'setup' ]]; then
   ndim=$(grep -o "[0-9]\+$" <<< $(mcx query --dim -imx "$network"))
   ntab=$(wc -l < "$tabfile")
 
+  ntab=${ntab//[[:space:]]/}
+  ndim=${ndim//[[:space:]]/}
+
   if [[ $ntab != $ndim ]]; then
     echo "Dimension mismatch between network ($ndim) and tab file ($ntab)"
     false


### PR DESCRIPTION
Fixes a bug where whitespace in the extracted ntab and ndim caused the program to exit when the dimensions of the network and tab files were in fact the same.